### PR TITLE
ADDON-002..007: scaffold addon and base files

### DIFF
--- a/.codex/tasks.yml
+++ b/.codex/tasks.yml
@@ -1,0 +1,117 @@
+- id: ADDON-001
+  title: Initialise repository skeleton
+  kind: chore
+  status: done
+
+- id: ADDON-002
+  title: Add VS Code dev-container (Supervisor + HA)
+  kind: env
+  status: done
+  requires: [ADDON-001]
+
+- id: ADDON-003
+  title: Scaffold add-on directory "obsidian/"
+  kind: feature
+  status: done
+  requires: [ADDON-001]
+
+- id: ADDON-004
+  title: Draft production config.yaml (v0.1.0)
+  kind: feature
+  status: done
+  requires: [ADDON-003]
+
+- id: ADDON-005
+  title: Create run.sh (env export + /config→/data symlink + exec /init)
+  kind: feature
+  status: done
+  requires: [ADDON-003]
+
+- id: ADDON-006
+  title: Add translations/en.yaml stub
+  kind: docs
+  status: done
+  requires: [ADDON-003]
+
+- id: ADDON-007
+  title: repository.yaml (store manifest)
+  kind: feature
+  status: done
+  requires: [ADDON-001]
+
+- id: ADDON-008
+  title: Commit branding assets and reference in config
+  kind: docs
+  status: todo
+  requires: [ADDON-003]
+  subtasks:
+    - id: ADDON-008a
+      title: Design icon.png 128×128 (transparent PNG)
+      status: todo
+    - id: ADDON-008b
+      title: Design logo.png ≈250×100
+      status: todo
+    - id: ADDON-008c
+      title: Add files to obsidian/ and update config.yaml
+      status: todo
+
+- id: ADDON-009
+  title: Compose README.md (root) and DOCS.md (add-on panel)
+  kind: docs
+  status: todo
+  requires: [ADDON-004, ADDON-005]
+
+- id: ADDON-010
+  title: GitHub Action – Add-on linter on push/PR
+  kind: ci
+  status: todo
+  requires: [ADDON-003]
+
+- id: ADDON-011
+  title: GitHub Action – Release pipeline (tag → bump version → GitHub Release)
+  kind: ci
+  status: todo
+  requires: [ADDON-004]
+
+- id: ADDON-012
+  title: Functional smoke-test matrix
+  kind: test
+  status: todo
+  requires: [ADDON-004, ADDON-005, ADDON-010]
+  subtasks:
+    - id: ADDON-012a
+      title: Dev-container (amd64) test
+      status: todo
+    - id: ADDON-012b
+      title: Raspberry Pi 4 (aarch64) test
+      status: todo
+    - id: ADDON-012c
+      title: x86-64 VM test
+      status: todo
+    - id: ADDON-012d
+      title: Document results in TESTS.md
+      status: todo
+
+- id: ADDON-013
+  title: Publish v0.1.0 Git tag (triggers release workflow)
+  kind: release
+  status: todo
+  requires: [ADDON-008, ADDON-009, ADDON-012, ADDON-011]
+
+- id: ADDON-015
+  title: Optional GPU toggle (`video: true`) in UI
+  kind: feature
+  status: backlog
+  requires: [ADDON-013]
+
+- id: ADDON-016
+  title: Advanced KasmVNC quality/resolution settings
+  kind: feature
+  status: backlog
+  requires: [ADDON-013]
+
+- id: ADDON-017
+  title: CodeNotary image signing in release pipeline
+  kind: ci
+  status: backlog
+  requires: [ADDON-013]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+    "name": "Home Assistant Add-ons",
+    "image": "ghcr.io/home-assistant/devcontainer:addons",
+    "appPort": ["7123:8123", "7357:4357"],
+    "postStartCommand": "bash devcontainer_bootstrap",
+    "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
+    "remoteUser":"root",
+    "containerEnv": {
+      "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"
+    },
+    "extensions": ["timonwong.shellcheck", "esbenp.prettier-vscode"],
+    "mounts": [ "type=volume,target=/var/lib/docker" ],
+    "settings": {
+      "terminal.integrated.profiles.linux": {
+        "zsh": {
+          "path": "/usr/bin/zsh"
+        }
+      },
+      "terminal.integrated.defaultProfile.linux": "zsh",
+      "editor.formatOnPaste": false,
+      "editor.formatOnSave": true,
+      "editor.formatOnType": true,
+      "files.trimTrailingWhitespace": true
+    }
+  }

--- a/.devcontainer/supervisor.sh
+++ b/.devcontainer/supervisor.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -eE
+
+SUPERVISOR_VERSON="$(curl -s https://version.home-assistant.io/dev.json | jq -e -r '.supervisor')"
+DOCKER_TIMEOUT=30
+DOCKER_PID=0
+
+function start_docker() {
+    local starttime
+    local endtime
+
+    if grep -q 'Alpine|standard-WSL' /proc/version; then
+        update-alternatives --set iptables /usr/sbin/iptables-legacy || echo "Fails adjust iptables"
+        update-alternatives --set ip6tables /usr/sbin/iptables-legacy || echo "Fails adjust ip6tables"
+    fi
+
+    echo "Starting docker."
+    dockerd 2> /dev/null &
+    DOCKER_PID=$!
+
+    echo "Waiting for docker to initialize..."
+    starttime="$(date +%s)"
+    endtime="$(date +%s)"
+    until docker info >/dev/null 2>&1; do
+        if [ $((endtime - starttime)) -le $DOCKER_TIMEOUT ]; then
+            sleep 1
+            endtime=$(date +%s)
+        else
+            echo "Timeout while waiting for docker to come up"
+            exit 1
+        fi
+    done
+    echo "Docker was initialized"
+}
+
+function stop_docker() {
+    if [ -n "$DOCKER_PID" ]; then
+        echo "Stopping docker..."
+        kill "$DOCKER_PID"
+        local starttime="$(date +%s)"
+        local endtime="$(date +%s)"
+        while kill -0 "$DOCKER_PID" >/dev/null 2>&1; do
+            if [ $((endtime - starttime)) -le $DOCKER_TIMEOUT ]; then
+                sleep 1
+                endtime="$(date +%s)"
+            else
+                echo "Timeout while waiting for dockerd to stop"
+                break
+            fi
+        done
+    fi
+}
+
+function cleanup_lastboot() {
+    mkdir -p /etc/docker
+    echo '{}' > /etc/docker/daemon.json
+}
+
+function cleanup_docker() {
+    echo "Clean up docker"
+    docker system prune -af
+}
+
+function run_supervisor() {
+    docker run --name hassio_supervisor \
+        --privileged \
+        --security-opt apparmor:unconfined \
+        -v /run/dbus:/run/dbus:ro \
+        -v /run/docker.sock:/run/docker.sock \
+        -v supervisor-data:/data \
+        -e SUPERVISOR_SHARE=/data \
+        -e SUPERVISOR_NAME=hassio_supervisor \
+        -e SUPERVISOR_MACHINE=qemux86-64 \
+        -e HOMEASSISTANT_REPOSITORY=homeassistant/qemux86-64-homeassistant \
+        ghcr.io/home-assistant/amd64-hassio-supervisor:"${SUPERVISOR_VERSON}"
+}
+
+function init_dbus() {
+    if pgrep dbus-daemon; then
+        echo "dbus already running"
+        return 0
+    fi
+
+    echo "Startup dbus"
+
+    rm -fr /var/run/dbus
+    mkdir -p /var/run/dbus
+    dbus-daemon --system --print-address
+}
+
+function init_udev() {
+    if pgrep systemd-udevd; then
+        echo "udev is running"
+        return 0
+    fi
+
+    echo "Startup udev"
+    mkdir -p /run/udev
+    /lib/systemd/systemd-udevd --daemon
+    sleep 3
+    udevadm trigger && udevadm settle
+}
+
+echo "Start Test-Env"
+
+start_docker
+trap "stop_docker" ERR
+
+docker system prune -f
+
+cleanup_lastboot
+cleanup_docker
+init_dbus
+init_udev
+run_supervisor
+stop_docker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,119 @@
+# AGENTS.md
+Guidelines for AI (and human) contributors to **adrianwedd/home-assistant-obsidian**
+
+This repository hosts a **pure-wrapper Home Assistant add-on** that embeds the
+official `lscr.io/linuxserver/obsidian` container via Ingress.
+The project is managed by granular tasks in `.codex/tasks.yml`.
+Follow the rules below so automated tools, ChatGPT prompts, and human PRs all
+produce consistent, merge-ready work.
+
+---
+
+## 1 ️⃣  Project pillars (never violate)
+
+| Pillar | Why it matters |
+|--------|----------------|
+| **Pure wrapper** – no Dockerfile, only `image:` key | Keeps builds instant, leverages upstream multi-arch image. |
+| **Init pattern** – `init: false` + `run.sh` → `exec /init` | Prevents double s6-overlay and mirrors official add-on style. |
+| **Symlink fix** – `/config` → `/data` | Guarantees data persistence across restarts & upgrades. |
+| **Ingress-first** – no host ports | Seamless SSO; smaller attack surface. |
+| **Minimal privileges** – unprivileged by default | Security trumps convenience. `full_access:` is backlog only. |
+
+Any change that breaks a pillar must raise an issue first.
+
+---
+
+## 2 ️⃣  Task workflow
+
+### 2.1 `.codex/tasks.yml`
+* Treat each `id:` as a single, atomic deliverable.
+* Update the `status:` field (`todo` → `in-progress` → `done`) in the same PR
+  that implements the task.
+
+### 2.2 Commit message convention
+
+ADDON-00X: short imperative summary
+
+*One task per commit* unless trivially related (e.g., docs tweaks).
+
+### 2.3 Pull-request checklist
+- [ ] Task ID present in title & body
+- [ ] `pre-commit run --all-files` passes (markdown-lint, shell-check, etc.)
+- [ ] `ha dev addon lint` returns **0 errors / 0 warnings**
+- [ ] Updated docs if user-visible behaviour changed
+
+---
+
+## 3 ️⃣  Branching & naming
+
+| Purpose | Branch prefix | Example |
+|---------|---------------|---------|
+| Feature / task implementation | `feat/ADDON-004-` | `feat/ADDON-004-config-yaml` |
+| Docs-only | `docs/ADDON-009-` | `docs/ADDON-009-readme` |
+| CI / infra | `ci/` | `ci/github-actions-cache` |
+
+PRs must target `main`.
+
+---
+
+## 4 ️⃣  Linting & CI
+
+| Tool | Trigger | Notes |
+|------|---------|-------|
+| **Addon-linter** (`frenck/action-addon-linter`) | Every push / PR | Validates `config.yaml`, icons, translations. |
+| **Release workflow** | Git tag `v*.*.*` | Bumps `version` in `config.yaml`, publishes GitHub Release. |
+| **Renovate** | Nightly | Opens PR when new linuxserver/obsidian tag appears. |
+
+Agents must **never** merge failing CI.
+
+---
+
+## 5 ️⃣  File-specific rules
+
+| File | Who edits | Rule |
+|------|-----------|------|
+| `obsidian/config.yaml` | Tasks `ADDON-004`, `ADDON-008c`, `ADDON-013` only | `version:` **must equal** Docker image tag. |
+| `run.sh` | Task `ADDON-005` | Keep shebang `#!/usr/bin/with-contenv bashio`. |
+| `README.md` & `DOCS.md` | Task `ADDON-009` or docs fixes | Must stay in sync; update both. |
+| `translations/en.yaml` | Task `ADDON-006` | Always valid YAML; keys match `config.yaml` options. |
+
+---
+
+## 6 ️⃣  Testing matrix (ADDON-012)
+
+* **Dev-container (amd64)** – Mandatory
+* **Raspberry Pi 4 (aarch64)** – Mandatory
+* **x86-64 VM** – Mandatory
+* **Pi 3 / armv7** – Optional but desirable
+
+Record pass/fail and resource metrics in `/TESTS.md`.
+
+---
+
+## 7 ️⃣  Sensitive actions
+
+| Action | Allowed by | Procedure |
+|--------|-----------|-----------|
+| Bumping `version` & image tag | `ADDON-013` release workflow only | Never bump manually outside the workflow. |
+| Enabling `full_access` | Future task only | Must include detailed security rationale in PR. |
+| Marketing / announcements | Out of scope | Not tracked in `.codex/tasks.yml`. |
+
+---
+
+## 8 ️⃣  Style guide (docs)
+
+* Use sentence-case headings (`## Accessing Obsidian`)
+* Wrap commands / paths in back-ticks.
+* Keep line length ≤ 120 chars.
+* Prefer ISO dates (`2025-06-22`).
+
+---
+
+## 9 ️⃣  When in doubt…
+
+1. Search the official HA add-on docs.
+2. Compare with patterns in **git_pull**, **glances**, **node-red** add-ons.
+3. Open an issue tagged **question** before coding.
+
+Happy hacking!
+*— The maintainers*

--- a/obsidian/config.yaml
+++ b/obsidian/config.yaml
@@ -1,0 +1,32 @@
+name: Obsidian
+version: "0.1.0"
+slug: obsidian
+description: A secure, self-hosted digital brain with Home Assistant integration.
+url: https://github.com/adrianwedd/home-assistant-obsidian
+arch:
+  - aarch64
+  - amd64
+  - armv7
+init: false
+image: lscr.io/linuxserver/obsidian:0.1.0
+tmpfs: true
+ingress: true
+ingress_port: 3000
+panel_icon: mdi:brain
+panel_title: Obsidian
+ports: {}
+watchdog: http://[HOST]:3000/
+memory: 512
+backup_exclude:
+  - BrowserCache/
+  - .cache/
+map:
+  - data:rw
+options:
+  puid: 1000
+  pgid: 1000
+  tz: UTC
+schema:
+  puid: int
+  pgid: int
+  tz: str

--- a/obsidian/run.sh
+++ b/obsidian/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/with-contenv bashio
+set -e
+
+# Symlink /data to /config to match linuxserver.io's expected data path.
+if [ ! -L /config ]; then
+  bashio::log.info "/config is not a symlink. Re-linking to /data..."
+  rm -rf /config
+  ln -s /data /config
+fi
+
+# Export user-provided options
+export PUID="$(bashio::config 'puid')"
+export PGID="$(bashio::config 'pgid')"
+export TZ="$(bashio::config 'tz')"
+
+exec /init

--- a/obsidian/translations/en.yaml
+++ b/obsidian/translations/en.yaml
@@ -1,0 +1,10 @@
+configuration:
+  puid:
+    name: "User ID (PUID)"
+    description: "The user ID for file permissions. See addon documentation for details."
+  pgid:
+    name: "Group ID (PGID)"
+    description: "The group ID for file permissions. See addon documentation for details."
+  tz:
+    name: "Timezone"
+    description: "Your local timezone (e.g., 'America/New_York')."

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,3 @@
+name: "Obsidian Home Assistant Addon"
+url: "https://github.com/adrianwedd/home-assistant-obsidian"
+maintainer: "Your Name <your-email@example.com>"


### PR DESCRIPTION
## Summary
- set up devcontainer with Supervisor script
- provide contributor guidelines in AGENTS.md
- create obsidian addon skeleton
- add initial `config.yaml` and `run.sh`
- stub out translations and repository manifest
- update task tracker for completed items

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `ha dev addon lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857d612ca58832a9049a69ff3f85be3