### PR TITLE
ADDON-012: document blocked tests

### DIFF
--- a/.codex/tasks.yml
+++ b/.codex/tasks.yml
@@ -76,21 +76,26 @@
 - id: ADDON-012
   title: Functional smoke-test matrix
   kind: test
-  status: todo
+  status: blocked
+  notes: |
+    Attempted in dev container but tests could not start:
+      - Docker daemon unavailable (permission denied)
+      - `ha` CLI and `pre-commit` missing
+    Resolve by using the official dev-container or enabling Docker access.
   requires: [ADDON-004, ADDON-005, ADDON-010]
   subtasks:
     - id: ADDON-012a
       title: Dev-container (amd64) test
-      status: todo
+      status: blocked
     - id: ADDON-012b
       title: Raspberry Pi 4 (aarch64) test
-      status: todo
+      status: blocked
     - id: ADDON-012c
       title: x86-64 VM test
-      status: todo
+      status: blocked
     - id: ADDON-012d
       title: Document results in TESTS.md
-      status: todo
+      status: blocked
 
 - id: ADDON-013
   title: Publish v0.1.0 Git tag (triggers release workflow)

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,0 +1,17 @@
+# Test results
+
+The add-on could not be run in this environment due to missing Docker privileges.
+Attempts to start `dockerd` failed with permission errors. The `ha` CLI and
+`pre-commit` were also unavailable, indicating the dev-container setup is
+incomplete.
+
+| Platform | Pass/Fail | Memory (MB) | CPU (%) | Notes |
+|---|---|---|---|---|
+| Dev-container (amd64) | Fail | N/A | N/A | `dockerd` failed: permission denied |
+| Raspberry Pi 4 (aarch64) | Not tested | N/A | N/A | Hardware unavailable |
+| x86-64 VM | Not tested | N/A | N/A | Hardware unavailable |
+
+No resource metrics could be collected.
+
+Testing was blocked by missing Docker privileges and missing tools.
+The ADDON-012 tasks remain blocked until Docker access is resolved.


### PR DESCRIPTION
## Summary
- mark ADDON-012 tasks as blocked rather than done
- elaborate on missing Docker and tooling in TESTS.md

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `ha dev addon lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e2d66280832a99ffd21188a742d4