### PR TITLE
ADDON-012a: update devcontainer dependencies

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,18 @@
     "name": "Home Assistant Add-ons",
     "image": "ghcr.io/home-assistant/devcontainer:addons",
     "appPort": ["7123:8123", "7357:4357"],
+    "features": {
+      "ghcr.io/devcontainers/features/docker-in-docker:2": {
+        "version": "latest",
+        "moby": "false"
+      },
+      "ghcr.io/devcontainers/features/python:1": {
+        "version": "3.11"
+      }
+    },
     "postStartCommand": "bash devcontainer_bootstrap",
-    "postCreateCommand": "pip install pre-commit && pre-commit install && pip install git+https://github.com/home-assistant/cli@main",
-    "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged", "-v", "/var/run/docker.sock:/var/run/docker.sock"],
+    "postCreateCommand": "pipx install pre-commit && pre-commit install --install-hooks && pipx install homeassistant-cli",
+    "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
     "remoteUser":"root",
     "containerEnv": {
       "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"


### PR DESCRIPTION
## Summary
- install Docker and Python via devcontainer features
- use pipx for homeassistant-cli and pre-commit

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `ha dev addon lint .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68589ca435d4832aa1f0bfa4dc49357d