### PR TITLE
ADDON-009: mark docs and linter tasks done

### DIFF
--- a/.codex/tasks.yml
+++ b/.codex/tasks.yml
@@ -58,13 +58,13 @@
 - id: ADDON-009
   title: Compose README.md (root) and DOCS.md (add-on panel)
   kind: docs
-  status: todo
+  status: done
   requires: [ADDON-004, ADDON-005]
 
 - id: ADDON-010
   title: GitHub Action – Add-on linter on push/PR
   kind: ci
-  status: todo
+  status: done
   requires: [ADDON-003]
 
 - id: ADDON-011


### PR DESCRIPTION
## Summary
- mark ADDON-009 README/DOCS docs task as done
- mark ADDON-010 linter workflow task as done

## Testing
- `pre-commit run --all-files`
- `ha dev addon lint obsidian` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858b8c0f488832ab1e47d5faf17872a