### PR TITLE
ADDON-018: add gitignore

### DIFF
--- a/.codex/tasks.yml
+++ b/.codex/tasks.yml
@@ -118,3 +118,9 @@
   kind: ci
   status: backlog
   requires: [ADDON-013]
+
+- id: ADDON-018
+  title: Add .gitignore
+  kind: chore
+  status: done
+  requires: [ADDON-001]

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.so
+*.egg
+*.egg-info/
+.eggs/
+.Python
+dist/
+build/
+*.pyo
+*.pyd
+*.whl
+pip-wheel-metadata/
+.pytest_cache/
+
+# Virtual environments
+.env/
+.venv/
+venv/
+ENV/
+
+# VS Code settings
+.vscode/
+
+# Home Assistant runtime files
+home-assistant.log
+home-assistant.log.*
+home-assistant_v2.db*
+*.db
+


### PR DESCRIPTION
## Summary
- add .gitignore for Python, VS Code and HA artifacts
- track new task ADDON-018 as done

## Testing
- `pre-commit run --all-files`
- `ha dev addon lint obsidian` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858b8ecee5c832a96d7954f7c8f9d50