### PR TITLE
ADDON-012: add version sync test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,3 @@ home-assistant.log
 home-assistant.log.*
 home-assistant_v2.db*
 *.db
-

--- a/TESTS.md
+++ b/TESTS.md
@@ -4,6 +4,8 @@ Pre-commit hooks now run locally without errors.
 `ha dev addon lint` could not be executed because the `ha` binary is missing in
 this environment.
 
+Run `pytest tests/test_version_sync.py` to confirm the config version matches the Docker image tag.
+
 | Platform | Pass/Fail | Memory (MB) | CPU (%) | Notes |
 |---|---|---|---|---|
 | Dev-container (amd64) | Fail | N/A | N/A | `dockerd` failed: permission denied |

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -1,0 +1,8 @@
+import yaml
+
+def test_version_matches_image_tag():
+    with open('obsidian/config.yaml') as f:
+        cfg = yaml.safe_load(f)
+    version = str(cfg['version'])
+    image_tag = str(cfg['image']).split(':')[-1]
+    assert version == image_tag, f"version {version} does not match image tag {image_tag}"


### PR DESCRIPTION
## Summary
- add `tests/test_version_sync.py` to ensure version matches image tag
- document how to run the new test

## Testing
- `pre-commit run --all-files`
- `ha dev addon lint` *(fails: command not found)*
- `pytest tests/test_version_sync.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6858b9fb0a08832a80dcfd36fd498850