### PR TITLE
ADDON-019: add markdownlint and shellcheck hooks

### DIFF
--- a/.codex/tasks.yml
+++ b/.codex/tasks.yml
@@ -124,3 +124,9 @@
   kind: chore
   status: done
   requires: [ADDON-001]
+
+- id: ADDON-019
+  title: Add markdownlint and shellcheck pre-commit hooks
+  kind: chore
+  status: done
+  requires: [ADDON-018]

--- a/.devcontainer/supervisor.sh
+++ b/.devcontainer/supervisor.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck shell=bash disable=SC2155
 set -eE
 
 SUPERVISOR_VERSON="$(curl -s https://version.home-assistant.io/dev.json | jq -e -r '.supervisor')"

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,11 @@
+default: true
+MD041: false
+MD013: false
+MD022: false
+MD032: false
+MD004: false
+MD029: false
+MD012: false
+MD034: false
+MD005: false
+MD007: false

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,11 @@
+all
+exclude_rule "MD004"
+exclude_rule "MD005"
+exclude_rule "MD007"
+exclude_rule "MD012"
+exclude_rule "MD013"
+exclude_rule "MD022"
+exclude_rule "MD029"
+exclude_rule "MD032"
+exclude_rule "MD002"
+exclude_rule "MD034"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,11 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.39.0
+    hooks:
+      - id: markdownlint
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.9.0.6
+    hooks:
+      - id: shellcheck

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,6 +1,7 @@
 # Test results
 
 Pre-commit hooks now run locally without errors.
+The hook suite now includes `markdownlint` and `shellcheck`.
 `ha dev addon lint` could not be executed because the `ha` binary is missing in
 this environment.
 

--- a/obsidian/run.sh
+++ b/obsidian/run.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/with-contenv bashio
+# shellcheck shell=bash disable=SC2155
 set -e
 
 # Symlink /data to /config to match linuxserver.io's expected data path.


### PR DESCRIPTION
## Summary
- add markdownlint and shellcheck hooks to pre-commit
- document additional hooks in TESTS.md
- disable SC2155 warnings for scripts
- add markdownlint config and task entry

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_6858bb2dfe70832a8b18ce108537c125