### PR TITLE
ADDON-002 fix supervisor version variable

### DIFF
--- a/.devcontainer/supervisor.sh
+++ b/.devcontainer/supervisor.sh
@@ -2,7 +2,7 @@
 # shellcheck shell=bash disable=SC2155
 set -eE
 
-SUPERVISOR_VERSON="$(curl -s https://version.home-assistant.io/dev.json | jq -e -r '.supervisor')"
+SUPERVISOR_VERSION="$(curl -s https://version.home-assistant.io/dev.json | jq -e -r '.supervisor')"
 DOCKER_TIMEOUT=30
 DOCKER_PID=0
 
@@ -73,7 +73,7 @@ function run_supervisor() {
         -e SUPERVISOR_NAME=hassio_supervisor \
         -e SUPERVISOR_MACHINE=qemux86-64 \
         -e HOMEASSISTANT_REPOSITORY=homeassistant/qemux86-64-homeassistant \
-        ghcr.io/home-assistant/amd64-hassio-supervisor:"${SUPERVISOR_VERSON}"
+        ghcr.io/home-assistant/amd64-hassio-supervisor:"${SUPERVISOR_VERSION}"
 }
 
 function init_dbus() {


### PR DESCRIPTION
## Summary
- fix SUPERVISOR_VERSION variable name in devcontainer script

## Testing
- `pre-commit run --all-files`
- `ha dev addon lint` *(fails: command not found)*
- `bash .devcontainer/supervisor.sh` *(fails: timeout waiting for docker)*

------
https://chatgpt.com/codex/tasks/task_e_6858bdf84970832a807ceda9bda2f6fb