### PR TITLE
ADDON-012: add devcontainer bootstrap script

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -35,6 +35,9 @@ It follows the "pure wrapper" philosophy – no Dockerfile here – so updates a
 
 4. **Start** the add-on → **Open Web UI** (or click the 🧠 Obsidian icon in the sidebar).
 5. **Create your vault** inside `/config/MyVault` (maps to the add-on’s persistent storage).
+
+The dev container runs `devcontainer_bootstrap` on startup to install test dependencies and start a lightweight Supervisor.
+
 ---
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ code .
 # Reopen in Dev Container → HA boots on http://localhost:8123
 ```
 
+The container runs `devcontainer_bootstrap` on start to install test dependencies
+and launch a lightweight Home Assistant Supervisor.
+
 *Lint locally:* `ha dev addon lint`
 CI must pass and docs remain in sync for PRs to be merged.
 

--- a/devcontainer_bootstrap
+++ b/devcontainer_bootstrap
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Python dependencies for tests
+pip install --no-cache-dir -q pytest docker requests pyyaml
+
+# Start Home Assistant Supervisor for development if not already running
+if ! docker ps --format '{{.Names}}' | grep -q hassio_supervisor; then
+    bash .devcontainer/supervisor.sh >/tmp/supervisor.log 2>&1 &
+fi
+
+echo "Devcontainer bootstrap complete."


### PR DESCRIPTION
## Summary
- add `devcontainer_bootstrap` with Python deps and supervisor start
- document bootstrap behaviour in README and DOCS

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_version_sync.py`
- `ha dev addon lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68626289e6f8832ab62b3f2e9a71fd75