### PR TITLE
ADDON-011: add initial CHANGELOG

### DIFF
--- a/.codex/tasks.yml
+++ b/.codex/tasks.yml
@@ -59,7 +59,7 @@
 - id: ADDON-011
   title: GitHub Action – Release pipeline (tag → bump version → GitHub Release)
   kind: ci
-  status: in-progress
+  status: done
   requires: [ADDON-004]
 
 - id: ADDON-012

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## v0.1.0 - 2025-06-22
+- Initial public release – pure wrapper, Ingress, multi-arch.


### PR DESCRIPTION
## Summary
- add CHANGELOG with first release notes
- mark release pipeline task as complete

## Testing
- `pre-commit run --all-files`
- `ha dev addon lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862628c19e0832aba98328a81f23724