### PR TITLE
ADDON-020: enforce commit prefix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,10 @@ repos:
     rev: v0.9.0.6
     hooks:
       - id: shellcheck
+  - repo: local
+    hooks:
+      - id: commit-msg-prefix
+        name: Check commit message prefix
+        entry: scripts/check_commit_msg.sh
+        language: script
+        stages: [commit-msg]

--- a/DOCS.md
+++ b/DOCS.md
@@ -38,6 +38,11 @@ It follows the "pure wrapper" philosophy – no Dockerfile here – so updates a
 
 The dev container runs `devcontainer_bootstrap` on startup to install test dependencies and start a lightweight Supervisor.
 
+### Contributing
+
+Use commit messages prefixed with `ADDON-XXX:` where `XXX` matches the task ID.
+Run `pre-commit run --all-files` and `ha dev addon lint` before pushing changes.
+
 ---
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ and launch a lightweight Home Assistant Supervisor.
 *Lint locally:* `ha dev addon lint`
 CI must pass and docs remain in sync for PRs to be merged.
 
+## Contributing
+
+Use commit messages that start with `ADDON-XXX:` where `XXX` is the task number.
+Run `pre-commit run --all-files` and `ha dev addon lint` before pushing.
+
 ---
 
 ## 🗺 Roadmap

--- a/scripts/check_commit_msg.sh
+++ b/scripts/check_commit_msg.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Fail if commit message does not start with ADDON-XXX: prefix
+msg_file="$1"
+if ! grep -qE '^ADDON-[0-9]{3}: ' "$msg_file"; then
+    echo "Commit message must start with 'ADDON-XXX: ' prefix" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- enforce commit prefix with a commit-msg hook
- highlight commit message style in CONTRIBUTING section

## Testing
- `pre-commit run --all-files`
- `ha dev addon lint obsidian` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686266361f78832aaf9d074ad943faaf