### PR TITLE
ADDON-020: disable vnc services

### DIFF
--- a/.codex/tasks.yml
+++ b/.codex/tasks.yml
@@ -119,3 +119,8 @@
   kind: chore
   status: done
   requires: [ADDON-018]
+
+- id: ADDON-020
+  title: Disable VNC and Openbox in devcontainer
+  kind: chore
+  status: done

--- a/devcontainer_bootstrap
+++ b/devcontainer_bootstrap
@@ -4,6 +4,14 @@ set -euo pipefail
 # Install Python dependencies for tests
 pip install --no-cache-dir -q pytest docker requests pyyaml
 
+# Stop optional GUI services that clutter logs
+for proc in openbox Xvnc kasmvnc; do
+    if pgrep -f "$proc" >/dev/null 2>&1; then
+        echo "Stopping $proc"
+        pkill -f "$proc" || true
+    fi
+done
+
 # Start Home Assistant Supervisor for development if not already running
 if ! docker ps --format '{{.Names}}' | grep -q hassio_supervisor; then
     bash .devcontainer/supervisor.sh >/tmp/supervisor.log 2>&1 &


### PR DESCRIPTION
## Summary
- disable leftover VNC/Openbox processes in `devcontainer_bootstrap`
- track task in `.codex/tasks.yml`

## Testing
- `pre-commit run --all-files`
- `ha dev addon lint ./obsidian` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68626b945ad0832aa7cc29982d9bb3db