### PR TITLE
ADDON-009: document gbm error

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -100,6 +100,7 @@ You can restore a snapshot on a new HA instance and your vault re‑appears inta
 | Blank screen / reconnect loop | Clear browser site‑data or restart the add‑on. |
 | Vault not saved | Ensure you created it under `/config/…`; anything under `/home` vanishes on restart. |
 | Add‑on keeps restarting | Check Supervisor log – watchdog fires if port 3000 stops responding. |
+| `Failed to create gbm` in logs | Set `LIBGL_ALWAYS_SOFTWARE=1` or mount `/dev/dri` with the `video` group. Hardware acceleration is not yet supported. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This repository wraps the `lscr.io/linuxserver/obsidian` container without a Doc
 
 * Runs **unprivileged**; no `full_access` or extra capabilities by default.
 * GPU passthrough is **deferred** to a future release.
+* If logs show `Failed to create gbm`, set `LIBGL_ALWAYS_SOFTWARE=1` or mount `/dev/dri` with the `video` group.
 * Automatic restart via healthcheck keeps the UI responsive.
 
 ---


### PR DESCRIPTION
## Summary
- document `Failed to create gbm` fix in README
- add same tip to DOCS troubleshooting

## Testing
- `pre-commit run --all-files`
- `ha dev addon lint` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686276acd048832aa9784435d8363dc3