### PR TITLE
ADDON-008: set software rendering default

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,8 @@
     "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
     "remoteUser":"root",
     "containerEnv": {
-      "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"
+      "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}",
+      "LIBGL_ALWAYS_SOFTWARE": "1"
     },
     "extensions": ["timonwong.shellcheck", "esbenp.prettier-vscode"],
     "mounts": [ "type=volume,target=/var/lib/docker" ],

--- a/DOCS.md
+++ b/DOCS.md
@@ -100,7 +100,7 @@ You can restore a snapshot on a new HA instance and your vault re‑appears inta
 | Blank screen / reconnect loop | Clear browser site‑data or restart the add‑on. |
 | Vault not saved | Ensure you created it under `/config/…`; anything under `/home` vanishes on restart. |
 | Add‑on keeps restarting | Check Supervisor log – watchdog fires if port 3000 stops responding. |
-| `Failed to create gbm` in logs | Set `LIBGL_ALWAYS_SOFTWARE=1` or mount `/dev/dri` with the `video` group. Hardware acceleration is not yet supported. |
+| `Failed to create gbm` in logs | `LIBGL_ALWAYS_SOFTWARE=1` is set by default; mount `/dev/dri` with the `video` group to enable passthrough. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This repository wraps the `lscr.io/linuxserver/obsidian` container without a Doc
 
 * Runs **unprivileged**; no `full_access` or extra capabilities by default.
 * GPU passthrough is **deferred** to a future release.
-* If logs show `Failed to create gbm`, set `LIBGL_ALWAYS_SOFTWARE=1` or mount `/dev/dri` with the `video` group.
+* The dev container sets `LIBGL_ALWAYS_SOFTWARE=1` by default; mount `/dev/dri` with the `video` group for GPU passthrough.
 * Automatic restart via healthcheck keeps the UI responsive.
 
 ---


### PR DESCRIPTION
## Summary
- set `LIBGL_ALWAYS_SOFTWARE=1` in devcontainer
- document default software rendering

## Testing
- `pre-commit run --all-files`
- `ha dev addon lint obsidian` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862807f1d48832a9bf4d206e17c6003