### PR TITLE
ADDON-009: bump docs version references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+Version numbers track the upstream `linuxserver/obsidian` image tag. The add-on
+version is bumped whenever the container tag changes.
+
 ## v0.1.0 - 2025-06-22
 - Initial public release – pure wrapper, Ingress, multi-arch.

--- a/DOCS.md
+++ b/DOCS.md
@@ -108,7 +108,7 @@ You can restore a snapshot on a new HA instance and your vault re‑appears inta
 
 | Version | Date | Notes |
 |---------|------|-------|
-| `0.1.0` | 2025‑06‑22 | Initial public release – pure wrapper, Ingress, multi‑arch. |
+| `1.5.12` | 2025‑06‑22 | Initial public release – pure wrapper, Ingress, multi‑arch. |
 
 ---
 

--- a/R&D.md
+++ b/R&D.md
@@ -89,7 +89,7 @@ This phase focuses on the meticulous construction of the addon's central manifes
 The first step is to give the addon a clear and professional identity.\[5\]
 
 * name: "Obsidian"
-* version: "0.1.0"
+* version: "1.5.12"
 * slug: "obsidian"
 * description: "A secure, self-hosted digital brain with Home Assistant integration."
 * url: A link to the addon's GitHub repository.

--- a/obsidian/DOCS.md
+++ b/obsidian/DOCS.md
@@ -64,7 +64,7 @@ You can restore a snapshot on a new HA instance and your vault re‑appears inta
 
 | Version | Date | Notes |
 |---------|------|-------|
-| `0.1.0` | 2025‑06‑22 | Initial public release – pure wrapper, Ingress, multi‑arch. |
+| `1.5.12` | 2025‑06‑22 | Initial public release – pure wrapper, Ingress, multi‑arch. |
 
 ---
 


### PR DESCRIPTION
## Summary
- update version references in docs to `1.5.12`
- clarify versioning scheme in `CHANGELOG.md`

## Testing
- `pre-commit run --all-files`
- `ha dev addon lint obsidian` *(fails: `ha` not found)*
- `pytest tests/test_version_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_6863ba1a4764832aa308e2183b5a1a08