### PR TITLE
ADDON-021: add headless container example

### DIFF
--- a/.codex/tasks.yml
+++ b/.codex/tasks.yml
@@ -124,3 +124,8 @@
   title: Disable VNC and Openbox in devcontainer
   kind: chore
   status: done
+
+- id: ADDON-021
+  title: Example Dockerfile with Helm chart for headless Obsidian
+  kind: docs
+  status: done

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ CI must pass and docs remain in sync for PRs to be merged.
 Use commit messages that start with `ADDON-XXX:` where `XXX` is the task number.
 Run `pre-commit run --all-files` and `ha dev addon lint` before pushing.
 
+## Example headless container
+
+A sample Dockerfile and Helm chart live under `examples/obsidian-headless`. Build with `docker build -t obsidian-headless examples/obsidian-headless` and run `docker run --rm -p 6901:6901 obsidian-headless`.
+
+
 ---
 
 ## 🗺 Roadmap

--- a/examples/obsidian-headless/.devcontainer/devcontainer.json
+++ b/examples/obsidian-headless/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "Obsidian Headless",
+  "build": { "dockerfile": "../Dockerfile" },
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+  "runArgs": [
+    "-p", "6901:6901",
+    "-e", "DISPLAY=:0",
+    "-e", "LIBGL_ALWAYS_SOFTWARE=1"
+  ],
+  "remoteUser": "root"
+}

--- a/examples/obsidian-headless/Dockerfile
+++ b/examples/obsidian-headless/Dockerfile
@@ -1,0 +1,33 @@
+FROM debian:bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DISPLAY=:0
+ENV LIBGL_ALWAYS_SOFTWARE=1
+
+# --- Dependencies ---
+RUN apt-get update && apt-get install -y \
+  wget curl unzip ca-certificates \
+  supervisor xvfb x11vnc openbox \
+  libnss3 libasound2 libxss1 libxtst6 libxkbfile1 \
+  libgtk-3-0 libnotify4 libx11-xcb1 libxcomposite1 libxcursor1 \
+  libxdamage1 libxi6 libxtst6 libnss3 libxrandr2 libxss1 libasound2 \
+  --no-install-recommends && \
+  rm -rf /var/lib/apt/lists/*
+
+# --- Install KasmVNC ---
+RUN mkdir -p /opt/kasmvnc && \
+    curl -L -o /opt/kasmvnc/kasmvnc.tar.gz https://kasmweb.com/files/kasmvnc/kasmvnc.tar.gz && \
+    tar -xzf /opt/kasmvnc/kasmvnc.tar.gz -C /opt/kasmvnc --strip-components=1 && \
+    chmod +x /opt/kasmvnc/kasmvnc
+
+# --- Download Obsidian AppImage ---
+RUN mkdir -p /opt/obsidian && \
+    curl -L -o /opt/obsidian/Obsidian.AppImage https://github.com/obsidianmd/obsidian-releases/releases/download/v1.5.3/Obsidian-1.5.3.AppImage && \
+    chmod +x /opt/obsidian/Obsidian.AppImage
+
+# --- Supervisor config ---
+COPY supervisord.conf /etc/supervisord.conf
+
+EXPOSE 6901
+
+CMD ["supervisord", "-c", "/etc/supervisord.conf"]

--- a/examples/obsidian-headless/README.md
+++ b/examples/obsidian-headless/README.md
@@ -1,0 +1,12 @@
+# Obsidian Headless Example
+
+This example container runs Obsidian in a headless environment using Xvfb and KasmVNC.
+
+## Build and run
+
+```bash
+docker build -t obsidian-headless .
+docker run --rm -it -p 6901:6901 obsidian-headless
+```
+
+Open `http://localhost:6901` in your browser to access the UI. Use `-v ~/myvault:/root/Obsidian` to persist data.

--- a/examples/obsidian-headless/charts/obsidian/Chart.yaml
+++ b/examples/obsidian-headless/charts/obsidian/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: obsidian
+description: Headless Obsidian running under KasmVNC
+type: application
+version: 0.1.0
+appVersion: "1.0"

--- a/examples/obsidian-headless/charts/obsidian/templates/deployment.yaml
+++ b/examples/obsidian-headless/charts/obsidian/templates/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: obsidian
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: obsidian
+  template:
+    metadata:
+      labels:
+        app: obsidian
+    spec:
+      containers:
+        - name: obsidian
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          env:
+            - name: DISPLAY
+              value: ":0"
+            - name: LIBGL_ALWAYS_SOFTWARE
+              value: "1"
+          ports:
+            - containerPort: 6901

--- a/examples/obsidian-headless/charts/obsidian/templates/service.yaml
+++ b/examples/obsidian-headless/charts/obsidian/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: obsidian
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 6901
+      name: http
+  selector:
+    app: obsidian

--- a/examples/obsidian-headless/charts/obsidian/values.yaml
+++ b/examples/obsidian-headless/charts/obsidian/values.yaml
@@ -1,0 +1,6 @@
+image:
+  repository: obsidian-headless
+  tag: latest
+service:
+  type: ClusterIP
+  port: 80

--- a/examples/obsidian-headless/supervisord.conf
+++ b/examples/obsidian-headless/supervisord.conf
@@ -1,0 +1,34 @@
+[supervisord]
+nodaemon=true
+logfile=/var/log/supervisord.log
+
+[program:xvfb]
+command=/usr/bin/Xvfb :0 -screen 0 1920x1080x24
+priority=1
+autostart=true
+autorestart=true
+startsecs=3
+
+[program:openbox]
+command=/usr/bin/openbox
+priority=2
+autostart=true
+autorestart=true
+startsecs=3
+environment=DISPLAY=":0"
+
+[program:kasmvnc]
+command=/opt/kasmvnc/kasmvnc --port 6901
+priority=3
+autostart=true
+autorestart=true
+startsecs=3
+environment=DISPLAY=":0"
+
+[program:obsidian]
+command=/opt/obsidian/Obsidian.AppImage
+priority=4
+autostart=true
+autorestart=true
+startsecs=3
+environment=DISPLAY=":0"


### PR DESCRIPTION
## Summary
- add example Dockerfile running Obsidian headless with supervisord
- include devcontainer config and Helm chart
- document example in README
- track new task

## Testing
- `pre-commit run --files README.md .codex/tasks.yml examples/obsidian-headless/Dockerfile examples/obsidian-headless/supervisord.conf examples/obsidian-headless/README.md examples/obsidian-headless/.devcontainer/devcontainer.json examples/obsidian-headless/charts/obsidian/Chart.yaml examples/obsidian-headless/charts/obsidian/values.yaml examples/obsidian-headless/charts/obsidian/templates/deployment.yaml examples/obsidian-headless/charts/obsidian/templates/service.yaml`
- `ha dev addon lint` *(fails: Error: No such command 'dev')*

------
https://chatgpt.com/codex/tasks/task_e_6863bc505d74832a97d679dcf196d080