### PR TITLE
ADDON-017: update status to backlog and archive audit

### DIFF
--- a/.codex/tasks.yml
+++ b/.codex/tasks.yml
@@ -105,7 +105,7 @@
 - id: ADDON-017
   title: CodeNotary image signing in release pipeline
   kind: ci
-  status: done
+  status: backlog
   requires: [ADDON-013]
 
 - id: ADDON-018

--- a/docs/reviews/2025-07-09-tasks-verification.md
+++ b/docs/reviews/2025-07-09-tasks-verification.md
@@ -1,0 +1,123 @@
+**Tasks.yml Verification Report**
+
+**Overall Summary**
+
+Most tasks marked as `done` in `tasks.yml` are well represented in the repository. Documentation, configuration, CI workflows and example code exist and match the specified tasks. The testing matrix (ADDON-012) is partially implemented and still in progress. One discrepancy was found: ADDON-017 claims CodeNotary signing in the release pipeline, but no signing step is implemented in the workflow.
+
+---
+
+### Verification of `done` Tasks
+- **Task:** ADDON-001 – Update `README.md` License  
+  **Documented Status:** done  
+  **Validation Status:** ✅ Verified  
+  **Justification:** `README.md` ends with license information referencing MIT and the upstream GPL license
+- **Task:** ADDON-002 – Add `finish` script to `run.sh`  
+  **Documented Status:** done  
+  **Validation Status:** ✅ Verified  
+  **Justification:** `obsidian/finish.sh` exists and sends `SIGTERM` to the VNC service
+- **Task:** ADDON-003 – Add Renovate Configuration  
+  **Documented Status:** done  
+  **Validation Status:** ✅ Verified  
+  **Justification:** `renovate.json` provides basic Renovate configuration
+- **Task:** ADDON-004 – Add `codenotary.json`  
+  **Documented Status:** done  
+  **Validation Status:** ✅ Verified  
+  **Justification:** `codenotary.json` is present with signer details
+- **Task:** ADDON-005 – Add `ha` dev command to `TESTS.md`  
+  **Documented Status:** done  
+  **Validation Status:** ✅ Verified  
+  **Justification:** `TESTS.md` instructs running `ha dev addon lint`
+- **Task:** ADDON-006 – Add `armhf` to `arch` in `config.yaml`  
+  **Documented Status:** done  
+  **Validation Status:** ✅ Verified  
+  **Justification:** `obsidian/config.yaml` lists `armhf` in its architecture array
+- **Task:** ADDON-008a – Design icon.png 128×128  
+  **Documented Status:** done  
+  **Validation Status:** ✅ Verified  
+  **Justification:** `obsidian/icon.png` is committed (binary file present).
+- **Task:** ADDON-008b – Design logo.png ≈250×100  
+  **Documented Status:** done  
+  **Validation Status:** ✅ Verified  
+  **Justification:** `obsidian/logo.png` is committed (binary file present).
+- **Task:** ADDON-008c – Add files to obsidian/ and update config.yaml  
+  **Documented Status:** done  
+  **Validation Status:** ✅ Verified  
+  **Justification:** Branding assets are referenced in `repository.yaml` for icon and logo paths
+- **Task:** ADDON-009 – Compose README.md and DOCS.md  
+  **Documented Status:** done  
+  **Validation Status:** ✅ Verified  
+  **Justification:** Extensive README and DOCS exist explaining features and usage
+- **Task:** ADDON-010 – GitHub Action – Add-on linter  
+  **Documented Status:** done  
+  **Validation Status:** ✅ Verified  
+  **Justification:** `.github/workflows/lint.yml` runs `frenck/action-addon-linter` on push/PR
+- **Task:** ADDON-011 – GitHub Action – Release pipeline  
+  **Documented Status:** done  
+  **Validation Status:** ✅ Verified  
+  **Justification:** `.github/workflows/release.yml` defines a workflow triggered by tags that updates config, commits, and creates a GitHub Release
+- **Task:** ADDON-017 – CodeNotary image signing in release pipeline  
+  **Documented Status:** done  
+  **Validation Status:** ❌ Mismatch  
+  **Justification:** The release workflow lacks any step invoking CodeNotary or signing the image. Only version bumping and GitHub Release steps are present
+- **Task:** ADDON-018 – Add .gitignore  
+  **Documented Status:** done  
+  **Validation Status:** ✅ Verified  
+  **Justification:** `.gitignore` with typical patterns is committed
+- **Task:** ADDON-019 – Add markdownlint and shellcheck pre-commit hooks  
+  **Documented Status:** done  
+  **Validation Status:** ✅ Verified  
+  **Justification:** `.pre-commit-config.yaml` lists markdownlint and shellcheck hooks
+- **Task:** ADDON-020 – Disable VNC and Openbox in devcontainer  
+  **Documented Status:** done  
+  **Validation Status:** ✅ Verified  
+  **Justification:** `devcontainer_bootstrap` stops `openbox`, `Xvnc`, and `kasmvnc` processes on startup
+- **Task:** ADDON-021 – Example Dockerfile with Helm chart for headless Obsidian  
+  **Documented Status:** done  
+  **Validation Status:** ✅ Verified  
+  **Justification:** `examples/obsidian-headless/` contains a Dockerfile and Helm chart directory
+
+---
+
+### Verification of `in-progress` Tasks
+- **Task:** ADDON-012 – Functional smoke-test matrix  
+  **Documented Status:** in-progress  
+  **Validation Status:** ⚠️ Partial Implementation  
+  **Justification:** Testing scripts (`tests/smoke_test.py`, `tests/test_version_sync.py`) exist and TESTS.md shows incomplete results with many “In Progress” entries
+- **Task:** ADDON-012a – Dev-container (amd64) test  
+  **Documented Status:** in-progress  
+  **Validation Status:** ⚠️ Partial Implementation  
+  **Justification:** Test scripts run in the dev container, but results are not finalized in TESTS.md.
+- **Task:** ADDON-012b – Raspberry Pi 4 (aarch64) test  
+  **Documented Status:** blocked  
+  **Validation Status:** ✅ Verified  
+  **Justification:** No evidence of Raspberry Pi testing scripts or results.
+- **Task:** ADDON-012c – x86-64 VM test  
+  **Documented Status:** blocked  
+  **Validation Status:** ✅ Verified  
+  **Justification:** No implementation found for this environment.
+- **Task:** ADDON-012d – Document results in TESTS.md  
+  **Documented Status:** blocked  
+  **Validation Status:** ✅ Verified  
+  **Justification:** TESTS.md contains placeholders and notes but lacks completed results.
+- **Task:** ADDON-013 – Publish v0.1.0 Git tag  
+  **Documented Status:** in-progress  
+  **Validation Status:** ✅ Verified  
+  **Justification:** Release workflow exists but there is no tag in the repository and the version remains `1.5.12` in config, indicating the release process has not been executed.
+
+---
+
+### Verification of `backlog` Tasks
+- **Task:** ADDON-015 – Optional GPU toggle (`video: true`) in UI  
+  **Documented Status:** backlog  
+  **Validation Status:** ✅ Verified  
+  **Justification:** No code references to a video option or GPU toggle. Only mentioned in roadmap notes.
+- **Task:** ADDON-016 – Advanced KasmVNC quality/resolution settings  
+  **Documented Status:** backlog  
+  **Validation Status:** ✅ Verified  
+  **Justification:** No configuration or code related to advanced KasmVNC settings.
+
+---
+
+**Conclusion**
+
+Aside from ADDON‑017, which lacks the claimed CodeNotary signing step, all other tasks align with the statuses recorded in `tasks.yml`. The testing matrix is partially implemented, matching its `in-progress` status. No evidence was found that backlog tasks have been started. The repository largely reflects the intended plan.


### PR DESCRIPTION
## Summary
- update ADDON-017 status in tasks.yml
- add verification report to docs/reviews

## Testing
- `pre-commit run --all-files`
- `ha dev addon lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686df7f09128832ab708519b9fd067a8