### PR TITLE
ADDON-022: document ha CLI missing

### DIFF
--- a/.codex/tasks.yml
+++ b/.codex/tasks.yml
@@ -129,3 +129,13 @@
   title: Example Dockerfile with Helm chart for headless Obsidian
   kind: docs
   status: done
+
+- id: ADDON-022
+  title: `ha` CLI missing for local linting
+  kind: chore
+  priority: 1
+  status: blocked
+  notes: |
+    Running `ha dev addon lint` fails with `ha: command not found`.
+    Install the Home Assistant CLI binary or adjust docs to use the
+    correct command.


### PR DESCRIPTION
## Summary
- add blocker task for missing `ha` CLI

## Testing
- `pre-commit run --files .codex/tasks.yml`

------
https://chatgpt.com/codex/tasks/task_e_686df972fd60832aa0fa549059e1245d