### PR TITLE
ADDON-017: CodeNotary Docker signing

### DIFF
--- a/.codex/tasks.yml
+++ b/.codex/tasks.yml
@@ -105,7 +105,7 @@
 - id: ADDON-017
   title: CodeNotary image signing in release pipeline
   kind: ci
-  status: backlog
+  status: done
   requires: [ADDON-013]
 
 - id: ADDON-018

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,19 @@ jobs:
           git commit -m "Release ${{ github.ref_name }}"
           git push
 
+      - name: Sign and push Docker image
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          VCN_API_KEY: ${{ secrets.VCN_API_KEY }}
+        run: |
+          docker pull lscr.io/linuxserver/obsidian:latest
+          docker tag lscr.io/linuxserver/obsidian:latest "$IMAGE"
+          curl -sfL https://getvcn.sh | sh
+          vcn login --api-key "$VCN_API_KEY"
+          vcn notarize --file codenotary.json docker://$IMAGE
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          docker push "$IMAGE"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
## Summary
- sign the Docker image in the release workflow using CodeNotary
- push the notarized image before publishing a GitHub Release
- mark ADDON-017 as done

## Testing
- `pre-commit run --all-files`
- `ha dev addon lint` *(fails: command not found)*
- `pytest tests/test_version_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_686e0439ea14832aad0a79f90704de15