### PR TITLE
Fix Docker build: use repo root as context, remove deleted ASCII art

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -62,7 +62,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: ./container
+          context: .
+          file: ./container/Dockerfile
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -70,10 +70,8 @@ RUN wget -O Obsidian.AppImage "https://github.com/obsidianmd/obsidian-releases/r
 # Configure NGINX for web interface
 COPY container/nginx.conf /etc/nginx/nginx.conf
 
-# Create startup script and copy ASCII art files
+# Create startup script
 COPY container/start.sh /opt/obsidian/scripts/start.sh
-COPY ../obsidian/obsidian-logo.txt /opt/obsidian/obsidian-logo.txt
-COPY ../obsidian/hass-obsidian-ascii-art.txt /opt/obsidian/hass-obsidian-ascii-art.txt
 RUN chmod +x /opt/obsidian/scripts/start.sh
 
 # Create health check script


### PR DESCRIPTION
## Summary

Two changes that together fix the `Build Custom Obsidian Container` workflow:

1. **Workflow**: build context changed from `./container` to `.` (repo root). The Dockerfile uses paths like `COPY container/nginx.conf` and `COPY ../obsidian/...` — these only resolve correctly with the repo root as context.
2. **Dockerfile**: removed `COPY` lines for `obsidian/obsidian-logo.txt` and `obsidian/hass-obsidian-ascii-art.txt`. Those files were deleted in commit 28951c5 (`ADDON-100: Fix performance degradation`) but never removed from the Dockerfile. `start.sh` already guards their absence with `[ -f ... ]` so the splash banner silently skips them.

Fixes #69.

## Test plan
- [ ] CI builds the container successfully
- [ ] Manifest is published to ghcr.io
- [ ] Container starts and obsidian process launches (without the splash banner)